### PR TITLE
Fix setting multiple roles

### DIFF
--- a/roles.js
+++ b/roles.js
@@ -99,11 +99,10 @@ program
   });
 
 program
-  .command("set <uid> <roles>")
+  .command("set <uid> <roles...>")
   .alias("update")
   .description("sets the roles for a user, will overwrite any existing roles")
   .action((uid, roles) => {
-    roles = roles.split(",");
 
     if (program.email) {
       const email = uid;


### PR DESCRIPTION
>set uid admin,premium

sets the role as ["admin premium"], odds are CLI parser eats the comma. changing <roles> to <roles...> tells it to expect an array, and

>set uid admin premium

sets the role as ["admin","premium"]

Note, the second command does not include a comma.